### PR TITLE
Multiple pkgnames + expose methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use nom::{
 };
 
 #[derive(Debug, PartialEq)]
-struct PkgBuild {
+pub struct PkgBuild {
     //mandatory fields
     pkgname: Vec<String>,
     pkgver: String,
@@ -19,7 +19,7 @@ struct PkgBuild {
 
 impl PkgBuild {
     // parsing mandatory fields in any order
-    fn parse(input: &str) -> IResult<&str, PkgBuild> {
+    pub fn parse(input: &str) -> IResult<&str, PkgBuild> {
         permutation((
             PkgBuild::parse_pkgname,
             PkgBuild::parse_pkgver,
@@ -49,7 +49,7 @@ impl PkgBuild {
         Ok((input, value.to_string()))
     }
 
-    fn parse_pkgname(input: &str) -> IResult<&str, Vec<String>> {
+    pub fn parse_pkgname(input: &str) -> IResult<&str, Vec<String>> {
         let (input, _) = tag("pkgname")(input)?;
         let (input, _) = space0(input)?;
         let (input, _) = tag("=")(input)?;
@@ -80,15 +80,15 @@ impl PkgBuild {
         Ok((input, names.iter().map(|s| s.to_string()).collect()))
     }
 
-    fn parse_pkgver(input: &str) -> IResult<&str, String> {
+    pub fn parse_pkgver(input: &str) -> IResult<&str, String> {
         Self::parse_field(input, "pkgver")
     }
 
-    fn parse_pkgrel(input: &str) -> IResult<&str, String> {
+    pub fn parse_pkgrel(input: &str) -> IResult<&str, String> {
         Self::parse_field(input, "pkgrel")
     }
 
-    fn parse_arch(input: &str) -> IResult<&str, Vec<String>> {
+    pub fn parse_arch(input: &str) -> IResult<&str, Vec<String>> {
         let (input, _) = tag("arch")(input)?;
         let (input, _) = space0(input)?;
         let (input, _) = tag("=")(input)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // A library to parse PKGBUILD files with Rust and Nom
 
 use nom::{
-    branch::permutation,
+    branch::{alt, permutation},
     bytes::complete::{tag, take_until, take_while1},
     character::complete::space0,
     multi::separated_list1,
@@ -11,7 +11,7 @@ use nom::{
 #[derive(Debug, PartialEq)]
 struct PkgBuild {
     //mandatory fields
-    pkgname: String,
+    pkgname: Vec<String>,
     pkgver: String,
     pkgrel: String,
     arch: Vec<String>,
@@ -49,8 +49,35 @@ impl PkgBuild {
         Ok((input, value.to_string()))
     }
 
-    fn parse_pkgname(input: &str) -> IResult<&str, String> {
-        Self::parse_field(input, "pkgname")
+    fn parse_pkgname(input: &str) -> IResult<&str, Vec<String>> {
+        let (input, _) = tag("pkgname")(input)?;
+        let (input, _) = space0(input)?;
+        let (input, _) = tag("=")(input)?;
+        let (input, _) = space0(input)?;
+        alt((Self::parse_pkgname_multiple, Self::parse_pkgname_single))(input)
+    }
+
+    fn parse_pkgname_single(input: &str) -> IResult<&str, Vec<String>> {
+        let (input, value) = take_until("\n")(input)?;
+        let (_, value) = alt((Self::single_quoted, |v| Ok((v, v))))(value)?;
+        let (input, _) = tag("\n")(input)?;
+        Ok((input, vec![value.to_string()]))
+    }
+
+    fn parse_pkgname_multiple(input: &str) -> IResult<&str, Vec<String>> {
+        let (input, _) = tag("(")(input)?;
+        let (input, pkgnames) = take_until(")")(input)?;
+        let (input, _) = tag(")")(input)?;
+        let (input, _) = space0(input)?;
+        let (input, _) = tag("\n")(input)?;
+        let names: Vec<&str> = pkgnames
+            .split_whitespace()
+            .map(|x| match Self::single_quoted(x) {
+                Ok(v) => v.1,
+                Err(_) => x,
+            })
+            .collect();
+        Ok((input, names.iter().map(|s| s.to_string()).collect()))
     }
 
     fn parse_pkgver(input: &str) -> IResult<&str, String> {
@@ -88,7 +115,34 @@ mod tests {
     #[test]
     fn pkgname() {
         let input = "pkgname=foo\n";
-        let expected = "foo";
+        let expected = vec!["foo"];
+        let (input, pkgname) = super::PkgBuild::parse_pkgname(input).unwrap();
+        assert_eq!(input, "");
+        assert_eq!(pkgname, expected);
+    }
+
+    #[test]
+    fn pkgname_quoted() {
+        let input = "pkgname='foo'\n";
+        let expected = vec!["foo"];
+        let (input, pkgname) = super::PkgBuild::parse_pkgname(input).unwrap();
+        assert_eq!(input, "");
+        assert_eq!(pkgname, expected);
+    }
+
+    #[test]
+    fn pkgname_multi() {
+        let input = "pkgname=(foo bar)\n";
+        let expected = vec!["foo", "bar"];
+        let (input, pkgname) = super::PkgBuild::parse_pkgname(input).unwrap();
+        assert_eq!(input, "");
+        assert_eq!(pkgname, expected);
+    }
+
+    #[test]
+    fn pkgname_multi_quoted() {
+        let input = "pkgname=('foo' 'bar')\n";
+        let expected = vec!["foo", "bar"];
         let (input, pkgname) = super::PkgBuild::parse_pkgname(input).unwrap();
         assert_eq!(input, "");
         assert_eq!(pkgname, expected);
@@ -125,7 +179,7 @@ mod tests {
     fn pkgbuild() {
         let input = "pkgname=foo\npkgver=1.0\npkgrel=1\narch=('i686' 'x86_64')\n";
         let expected = super::PkgBuild {
-            pkgname: "foo".to_string(),
+            pkgname: vec!["foo".to_string()],
             pkgver: "1.0".to_string(),
             pkgrel: "1".to_string(),
             arch: vec!["i686".to_string(), "x86_64".to_string()],


### PR DESCRIPTION
Hey, 
a pkgbuild can have multiple pkgnames specified when building multiple packages. 
I've also added aupport for single-quoted pkgnames.
Moreover you didn't expose any method to be accessible from other package / libs

-Lukas